### PR TITLE
feature: passing of a custom filterComponent

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -10,6 +10,7 @@ const MultiselectTwoSides = React.createClass({
 		clearable: React.PropTypes.bool,
 		deselectAllText: React.PropTypes.string,
 		disabled: React.PropTypes.bool,
+		filterComponent: React.PropTypes.func,
 		labelKey: React.PropTypes.string,
 		limit: React.PropTypes.number,
 		onChange: React.PropTypes.func,
@@ -163,19 +164,50 @@ const MultiselectTwoSides = React.createClass({
 		this.setState({filterSelected});
 	},
 
+	renderFilter(value, onChange) {
+		const {
+			clearFilterText,
+			clearable,
+			disabled,
+			filterComponent,
+			placeholder
+		} = this.props;
+
+		if (!filterComponent) {
+			return (
+				<Filter
+					value={value}
+					onChange={onChange}
+					{...{
+						clearFilterText,
+						clearable,
+						disabled,
+						placeholder
+					}}
+					/>
+			);
+		}
+
+		return React.createElement(filterComponent, {
+			clearFilterText,
+			clearable,
+			disabled,
+			onChange,
+			placeholder,
+			value
+		});
+	},
+
 	render() {
 		const {
 			availableFooter,
 			availableHeader,
 			className,
-			clearFilterText,
-			clearable,
 			deselectAllText,
 			disabled,
 			labelKey,
 			limit,
 			options,
-			placeholder,
 			searchable,
 			selectAllText,
 			selectedFooter,
@@ -209,29 +241,11 @@ const MultiselectTwoSides = React.createClass({
 				{searchable ? (
 					<div className="msts__subheading">
 						<div className="msts__side msts__side_filter">
-							<Filter
-								value={filterAvailable}
-								onChange={this.handleChangeFilterAvailable}
-								{...{
-									clearFilterText,
-									clearable,
-									disabled,
-									placeholder
-								}}
-								/>
+							{this.renderFilter(filterAvailable, this.handleChangeFilterAvailable)}
 						</div>
 
 						<div className="msts__side msts__side_filter">
-							<Filter
-								value={filterSelected}
-								onChange={this.handleChangeFilterSelected}
-								{...{
-									clearFilterText,
-									clearable,
-									disabled,
-									placeholder
-								}}
-								/>
+							{this.renderFilter(filterSelected, this.handleChangeFilterSelected)}
 						</div>
 					</div>
 				) : null}


### PR DESCRIPTION
Good day.

I've added a feature, so it would be possible to pass a custom React component to render the filters for a multiselect.
The problem I have in my project is that I need to write a completely custom markup for a search field to match the project design, so this seemed like a possible solution for me. I tested and it works.

Use case scenario:

Create a custom component for the Filter, e.g.:
```
const Filter = React.createClass({
	propTypes: {
		clearFilterText: React.PropTypes.string,
		clearable: React.PropTypes.bool,
		disabled: React.PropTypes.bool,
		onChange: React.PropTypes.func.isRequired,
		placeholder: React.PropTypes.string,
		value: React.PropTypes.string
	},

	handleChange(e) {
		this.props.onChange(e.target.value);
	},

	handleClickClear() {
		this.props.onChange('');
	},

	render() {
		const {
			clearFilterText,
			clearable,
			disabled,
			placeholder,
			onChange,
			value
		} = this.props;

		return (
			<div className="custom__filter">
				<div className="custom__stuff">Some custom stuff</div>
				<input
					className="custom-input"
					value={value}
					onChange={this.handleChange}
					type="text"
					placeholder={placeholder}
					disabled={disabled}
				/>
				{clearable && value && !disabled ? (
					<div className="custom-wrapper">
						<span
							className="custom__filter-clear"
							onClick={this.handleClickClear}
							title={clearFilterText}
						/>
					</div>
				) : null}
			</div>
		);
	}
});
```

And then I can pass it to the MultiselectTwoSides as a Prop.

```
<MultiselectTwoSides
	{...{options, value}}
	className="custom_theme_example"
	onChange={this.handleChange}
	availableHeader="Available"
	availableFooter={`Available: ${availableCount}`}
	selectedHeader="Selected"
	selectedFooter={`Selected: ${selectedCount}`}
	placeholder="Filter…"
	filterComponent={Filter}
	{...s}
	/>
```

Best regards,
Jevgenij.