### PR TITLE
build(package): Fix `create-react-app` build task fails on `class` minification

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     "react",
-    "modern-browsers"
+    "es2015"
   ],
   "env": {
     "production": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.12",
-    "babel-preset-modern-browsers": "^10.0.1",
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.26.0",
     "conventional-changelog-cli": "^1.3.4",


### PR DESCRIPTION
Build components with `es2015` babel preset instead of `modern-browsers`

fix #24